### PR TITLE
Update default.sls

### DIFF
--- a/srv/salt/omv/deploy/borgbackup/default.sls
+++ b/srv/salt/omv/deploy/borgbackup/default.sls
@@ -147,7 +147,7 @@ configure_borg_{{ archive.name }}_cron_file:
         export BORG_REPO='{{ rpath }}'
 
         # Setting this, so you won't be asked for your repository passphrase:
-        export BORG_PASSPHRASE='{{ ns.passphrase }}'
+        export BORG_PASSPHRASE='{{ ns.passphrase | replace("'", "'\\''") }}'
 
         # some helpers and error handling:
         info() { printf "\n%s %s\n\n" "$( date )" "$*"; }


### PR DESCRIPTION
I had a problem running Borg backup in OMV because my Borg passphrase contained a single quote resulting in the error '_passphrase supplied in BORG_PASSPHRASE, by BORG_PASSCOMMAND or via BORG_PASSPHRASE_FD is incorrect_'

This change escapes single quotes in the Borg passphrase.